### PR TITLE
Fix ALSA constructor and variable signedness

### DIFF
--- a/maolan/audio/alsa/base.hpp
+++ b/maolan/audio/alsa/base.hpp
@@ -10,7 +10,7 @@ namespace maolan::audio
 class ALSA : public IO
 {
 public:
-  ALSA(const std::string &device, const int &channels = 2,
+  ALSA(const std::string &device, const size_t &channels = 2,
        const snd_pcm_uframes_t &frames = 512);
   ~ALSA();
 

--- a/maolan/audio/alsa/in.hpp
+++ b/maolan/audio/alsa/in.hpp
@@ -8,7 +8,7 @@ namespace maolan::audio
 class ALSAIn : public ALSA
 {
 public:
-  ALSAIn(const std::string &device, const int &channels,
+  ALSAIn(const std::string &device, const size_t &channels,
          const snd_pcm_uframes_t &frames = 512);
 
   void fetch();

--- a/maolan/audio/alsa/out.hpp
+++ b/maolan/audio/alsa/out.hpp
@@ -10,7 +10,7 @@ namespace maolan::audio
 class ALSAOut : public ALSA, public Connectable
 {
 public:
-  ALSAOut(const std::string &device, const int &channels,
+  ALSAOut(const std::string &device, const size_t &channels,
           const snd_pcm_uframes_t &frames = 512);
 
   virtual void fetch();

--- a/src/audio/alsa/base.cpp
+++ b/src/audio/alsa/base.cpp
@@ -17,9 +17,9 @@ static void checkError(int &value, const std::string &message)
 using namespace maolan::audio;
 
 
-ALSA::ALSA(const std::string &deviceName, const int &chs,
+ALSA::ALSA(const std::string &deviceName, const size_t &chs,
            const snd_pcm_uframes_t &frames)
-    : IO(0, true, true, deviceName), device{nullptr}
+    : IO(deviceName, true, chs), device{nullptr}
 {
   bool found = false;
   for (const auto iter : IO::devices)
@@ -102,4 +102,4 @@ ALSA::~ALSA()
 }
 
 
-std::size_t ALSA::channels() const { return outputs.size(); }
+std::size_t ALSA::channels() const { return _outputs.size(); }

--- a/src/audio/alsa/in.cpp
+++ b/src/audio/alsa/in.cpp
@@ -4,7 +4,7 @@
 
 using namespace maolan::audio;
 
-ALSAIn::ALSAIn(const std::string &device, const int &chs,
+ALSAIn::ALSAIn(const std::string &device, const size_t &chs,
                const snd_pcm_uframes_t &frames)
     : ALSA(device, chs)
 {
@@ -22,17 +22,17 @@ void ALSAIn::fetch()
 void ALSAIn::process()
 {
   auto chs = channels();
-  int channel;
+  size_t channel;
   int index;
-  for (int i = 0; i < chs; ++i)
+  for (size_t i = 0; i < chs; ++i)
   {
-    outputs[i] = std::make_shared<BufferData>(Config::audioBufferSize);
+    _outputs[i] = std::make_shared<BufferData>(Config::audioBufferSize);
   }
   auto sizeLimit = device->fragSize / sizeof(*frame);
-  for (int i = 0; i < sizeLimit; ++i)
+  for (size_t i = 0; i < sizeLimit; ++i)
   {
     channel = i % chs;
     index = i / chs;
-    outputs[channel]->data()[index] = frame[i] / floatMaxInt;
+    _outputs[channel]->data()[index] = frame[i] / floatMaxInt;
   }
 }

--- a/src/audio/alsa/out.cpp
+++ b/src/audio/alsa/out.cpp
@@ -10,19 +10,19 @@
 using namespace maolan::audio;
 
 
-ALSAOut::ALSAOut(const std::string &device, const int &chs,
+ALSAOut::ALSAOut(const std::string &device, const size_t &chs,
                  const snd_pcm_uframes_t &frames)
     : ALSA(device, chs), Connectable(chs)
 {
   _type = "AudioALSAOut";
   _name = device;
-  outputs.resize(chs);
+  _outputs.resize(chs);
 }
 
 
 void ALSAOut::fetch()
 {
-  for (size_t i = 0; i < channels(); ++i) { outputs[i] = _inputs[i].pull(); }
+  for (size_t i = 0; i < channels(); ++i) { _outputs[i] = _inputs[i]->pull(); }
 }
 
 
@@ -31,10 +31,10 @@ void ALSAOut::convertToRaw()
   auto chs = channels();
   for (std::size_t channel = 0; channel < chs; ++channel)
   {
-    auto buffer = outputs[channel];
+    auto buffer = _outputs[channel];
     if (buffer == nullptr)
     {
-      for (int i = 0; i < device->audioBufferSize; ++i)
+      for (size_t i = 0; i < device->audioBufferSize; ++i)
       {
         frame[i * chs + channel] = 0;
       }

--- a/src/midi/connectable.cpp
+++ b/src/midi/connectable.cpp
@@ -9,7 +9,7 @@ Connectable::Connectable(const std::size_t &chs) { _inputs.resize(chs); }
 
 void Connectable::connect(IO *to)
 {
-  for (auto channel = 0; channel < _inputs.size(); ++channel)
+  for (size_t channel = 0; channel < _inputs.size(); ++channel)
   {
     connect(to, channel, channel);
   }


### PR DESCRIPTION
Variables countaining number of channels should always be unsigned, as having a negative number of channels is not possible.